### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+setup(
+    name="produce",
+    version="0.1",
+    packages=find_packages(),
+    scripts=['produce'],
+
+    # metadata to display on PyPI
+    author="Kilian Evang",
+    author_email="kilian@evang.name",
+    description="Replacement for Make geared towards processing data rather than compiling code",
+    license="MIT",
+    keywords="make builder automation",
+    url="https://github.com/texttheater/produce", 
+)


### PR DESCRIPTION
It would be nice if produce was installable from pip. Adding a `setup.py` is a first step for that. Even when using git directly, it also gives a straightforward way to add `produce` to one's path.

(https://pypi.org/project/produce is still available !)