### PR TITLE
Fix #46

### DIFF
--- a/produce
+++ b/produce
@@ -247,7 +247,7 @@ def process_commandline(args=None):
 
 SECTIONHEAD_PATTERN = re.compile(r'^\[(.*)\]\s*$')
 AVPAIR_PATTERN = re.compile(r'^(\S+?)\s*=\s*(.*)$', re.DOTALL)
-VALUECONT_PATTERN = re.compile(r'^(\s)(.*)$', re.DOTALL)
+VALUECONT_PATTERN = re.compile(r'^(\s+)(.*)$', re.DOTALL)
 COMMENT_PATTERN = re.compile(r'^\s*#.*$')
 BLANKLINE_PATTERN = re.compile(r'^\s*$')
 


### PR DESCRIPTION
Apparently the `VALUECONT_PATTERN` not gobbling as much spaces as it could in the first continuation line was the issue.

Also, should I add a testcase for this feature?

(Yeah, I got the issue number wrong in the commit message)