### PR TITLE
Add automatic releases to pypi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine pep517
+    - name: Build
+      run: |
+        python -m pep517.build --source --binary --out-dir dist/.
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      # Only publish on main pypi from main repo
+      if: github.repository == 'texttheater/produce'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ pip-log.txt
 .tox
 nosetests.xml
 
+# Tools cache
+.mypy_cache
+
 # Translations
 *.mo
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # C extensions
 *.so
 
+# Virtual environments
+.venv
+
 # Packages
 *.egg
 *.egg-info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Produce logo](img/logo/Produce_Logo_300.png)
+![Produce logo](https://raw.githubusercontent.com/texttheater/produce/master/img/logo/Produce_Logo_300.png)
 ==============================================
 
 Produce is an incremental build system for the command line, like Make or redo,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta" 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = produce
+version = 0.2
+author = Kilian Evang
+author_email = kilian.evang@gmail.com
+url = https://github.com/texttheater/produce 
+description = Replacement for Make geared towards processing data rather than compiling code
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+keywords=
+    make
+    builder
+    automation
+
+[options]
+packages = find:
+scripts =
+    produce

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,3 @@
-from setuptools import setup, find_packages
-setup(
-    name="produce",
-    version="0.2",
-    packages=find_packages(),
-    scripts=['produce'],
+from setuptools import setup
 
-    # metadata to display on PyPI
-    author="Kilian Evang",
-    author_email="kilian.evang@gmail.com",
-    description="Replacement for Make geared towards processing data rather than compiling code",
-    license="MIT",
-    keywords="make builder automation",
-    url="https://github.com/texttheater/produce", 
-)
+setup()


### PR DESCRIPTION
Meant as a fix for #48 

This adds a Github action triggered by adding a Github release that

1. Builds produce
2. Upload the build
  - On test.pypi.org (can be removed but does no harm)
  - On pypi.org if the release was on the original [texttheater/produce](https://github.com/texttheater/produce) repo

So the release process when you want to push a new version of produce is:

1. Update the version string in setup.cfg and push on github
2. Make a new release from the Github interface

For instance, [this pypi release](https://test.pypi.org/project/produce/0.2.2/) was triggered by [this gh release](https://github.com/LoicGrobol/produce/releases/tag/v0.2.2).

I personally prefer it this way because it makes it harder to screw things up if you use tags for things other than releases. If you'd rather have the pypi releases triggered by pushing a tag as originally suggested, it is also possible and also only for some tags (e.g. those starting with "v" or something). Tell me what you prefer!

Side-edits:

- The packaging metadata is now in setup.cfg instead of in setup.py and setup.py is now a mere stub. This allows an easier sourcing of the long description from README.md and is generally better practice, since we don't need to do anything funky in setup.py anyway.
- There is a now a long description for the package, which you can see on [test.pypi](https://test.pypi.org/project/produce/) (still lacking the logo atm, I'll fix that tomorrow.
- We now use a [PEP 517](https://www.python.org/dev/peps/pep-0517/) build (but still with the vanilla setuptools build system, so the change is minimal) since it seems to be the best practice for Python packaging at the moment and in the near future and it was no hard effort
- A few standard (er, as in “they are in Github's Python gitignore) ignored dirs for mypy and local virtualenvs